### PR TITLE
#8 prevent test app from crashing on android l devices

### DIFF
--- a/testapp/src/main/res/values-v21/styles.xml
+++ b/testapp/src/main/res/values-v21/styles.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <style name="AppTheme" parent="android:Theme.Material.Light">
-    </style>
-</resources>


### PR DESCRIPTION
- was crashing because of theme incompatibility, using same theme now on all android versions (AppCompat theme)