### PR TITLE
#1: basic preparation for upload to jcenter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ obj
 .idea/vcs.xml
 .idea/runConfigurations.xml
 .idea/gradle.xml
+.idea/dictionaries
 *.iml
 
 # other stuff

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.3.1'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.6-all.zip

--- a/webp_backport/build.gradle
+++ b/webp_backport/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23"
+    buildToolsVersion "23.0.0"
 
     defaultConfig {
         minSdkVersion 8
@@ -27,4 +27,143 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     androidTestCompile 'com.android.support:support-annotations:23.0.0'
     androidTestCompile 'org.apache.commons:commons-io:1.3.2'
+}
+
+//
+// Settings for publishing to jcenter.
+//
+// For details about how to setup your account at bintray.com please refer to section 1 of:
+//
+// http://inthecheesefactory.com/blog/how-to-upload-library-to-jcenter-maven-central-as-dependency/en
+//
+// Afterwards add the following to your local.properties:
+//
+// bintray.apikey=<see https://bintray.com/profile/edit -> API Key>
+// bintray.user=<your bintray username>
+//
+// Change the settings in the following section to be in line with your settings on bintray.
+//
+// Follow the steps in section 5 and 6 of the tutorial mentioned above to publish the artifacts
+// to jcenter.
+//
+// To upload a new version to jcenter run
+// ./gradlew bintrayUpload
+//
+
+ext {
+    bintrayName = 'TODO name of the package at bintray.com, e.g. webp-android-backport-library'
+
+    publishedGroupId = 'de.marcreichelt'
+    pomLibraryName = 'WebPAndroidBackportLibrary'
+
+    libraryDescription = 'TODO Add some nice description here...'
+
+    siteUrl = 'https://github.com/mreichelt/webp-android-backport-library'
+    gitUrl = 'https://github.com/mreichelt/webp-android-backport-library.git'
+
+    libraryVersion = android.defaultConfig.versionName
+
+    developerId = 'mcreichelt'
+    developerName = 'Marc Reichelt'
+    developerEmail = 'mcreichelt@gmail.com'
+
+    // TODO This needs to be changed! Bintray offers a limited number of licenses to be selected during setup of the package.
+    licenseName = 'The Apache Software License, Version 2.0'
+    licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+    allLicenses = ["Apache-2.0"]
+}
+
+//
+// From https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle
+//
+
+apply plugin: 'com.github.dcendents.android-maven'
+
+group = publishedGroupId
+
+install {
+    repositories.mavenInstaller {
+        // This generates POM.xml with proper parameters
+        pom {
+            project {
+                packaging 'aar'
+                groupId publishedGroupId
+
+                name pomLibraryName
+                description libraryDescription
+                url siteUrl
+
+                licenses {
+                    license {
+                        name licenseName
+                        url licenseUrl
+                    }
+                }
+                developers {
+                    developer {
+                        id developerId
+                        name developerName
+                        email developerEmail
+                    }
+                }
+                scm {
+                    connection gitUrl
+                    developerConnection gitUrl
+                    url siteUrl
+
+                }
+            }
+        }
+    }
+}
+
+//
+// From https://raw.githubusercontent.com/nuuneoi/JCenter/master/bintrayv1.gradle
+//
+
+apply plugin: 'com.jfrog.bintray'
+
+version = libraryVersion
+
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives javadocJar
+    archives sourcesJar
+}
+
+Properties properties = new Properties()
+properties.load(project.rootProject.file('local.properties').newDataInputStream())
+
+bintray {
+    user = properties.getProperty("bintray.user")
+    key = properties.getProperty("bintray.apikey")
+
+    configurations = ['archives']
+    pkg {
+        repo = 'maven'
+        name = bintrayName
+        desc = libraryDescription
+        websiteUrl = siteUrl
+        vcsUrl = gitUrl
+        licenses = allLicenses
+        publish = true
+        publicDownloadNumbers = true
+        version {
+            desc = libraryDescription
+        }
+    }
 }

--- a/webp_backport/build.gradle
+++ b/webp_backport/build.gradle
@@ -51,23 +51,23 @@ dependencies {
 //
 
 ext {
-    bintrayName = 'TODO name of the package at bintray.com, e.g. webp-android-backport-library'
+    bintrayRepo = 'maven'
+    bintrayName = 'webp-android-backport'
 
     publishedGroupId = 'de.marcreichelt'
-    pomLibraryName = 'WebPAndroidBackportLibrary'
+    pomLibraryName = bintrayName
 
-    libraryDescription = 'TODO Add some nice description here...'
+    libraryDescription = 'A library for easily using WebP on older Android versions via a native library.'
 
     siteUrl = 'https://github.com/mreichelt/webp-android-backport-library'
     gitUrl = 'https://github.com/mreichelt/webp-android-backport-library.git'
 
     libraryVersion = android.defaultConfig.versionName
 
-    developerId = 'mcreichelt'
+    developerId = 'mreichelt'
     developerName = 'Marc Reichelt'
     developerEmail = 'mcreichelt@gmail.com'
 
-    // TODO This needs to be changed! Bintray offers a limited number of licenses to be selected during setup of the package.
     licenseName = 'The Apache Software License, Version 2.0'
     licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
     allLicenses = ["Apache-2.0"]

--- a/webp_backport/src/main/java/de/marcreichelt/webp_backport/WebPBackport.java
+++ b/webp_backport/src/main/java/de/marcreichelt/webp_backport/WebPBackport.java
@@ -62,6 +62,8 @@ public class WebPBackport {
     /**
      * Returns whether WebP images can be decoded. More exact: if WebP is supported by the platform
      * or by the included native library.
+     *
+     * @return {@code true} if WebP is supported.
      */
     public static boolean isWebPSupported() {
         return isIsWebpSupportedNatively() || librarySuccessfullyLoaded;
@@ -69,6 +71,8 @@ public class WebPBackport {
 
     /**
      * Is the native library used to decode WebP images?
+     *
+     * @return {@code true} if the native library is used.
      */
     public static boolean isLibraryUsed() {
         return librarySuccessfullyLoaded;


### PR DESCRIPTION
Extended build system to support upload to jcenter.

Successfully uploaded the build artifacts (temporarily) to my own bintray account :-)

TODO:
* create bintray account and maven package within account
* update configuration in build.gradle (marked with TODO)
* upload artifacts to new account and publish to jcenter